### PR TITLE
Cepstrum notebook: add experiment for recorded sample

### DIFF
--- a/playground/cepstrum_pitch_detection.ipynb
+++ b/playground/cepstrum_pitch_detection.ipynb
@@ -687,6 +687,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The use of log didn't appear to make a significant difference on the accuracy of the algorithm in this case, though further experimentation may reveal additional insights."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# References"
    ]
   },


### PR DESCRIPTION
Added some results for the recorded sample.

Cepstrum doesn't seem promising as an approach on its own, but perhaps could be useful as inspiration elsewhere.