### PR TITLE
Updated gcloud script

### DIFF
--- a/deploy_to_gcloud/run.sh
+++ b/deploy_to_gcloud/run.sh
@@ -17,5 +17,6 @@ docker push $ARTIFACT_REGISTRY_IMAGE_URI
 # Deploy service to Cloud Run.
 python3 ./deploy_to_gcloud/compile_yaml.py ./deploy_to_gcloud/service.yaml > ./deploy_to_gcloud/service.compiled.yaml
 python3 ./deploy_to_gcloud/compile_yaml.py ./deploy_to_gcloud/policy.yaml > ./deploy_to_gcloud/policy.compiled.yaml
+gcloud run services delete --region $REGION $CLOUD_RUN_SERVICE
 gcloud run services replace ./deploy_to_gcloud/service.compiled.yaml
 gcloud run services set-iam-policy --region $REGION $CLOUD_RUN_SERVICE ./deploy_to_gcloud/policy.compiled.yaml

--- a/deploy_to_gcloud/service.yaml
+++ b/deploy_to_gcloud/service.yaml
@@ -19,5 +19,5 @@ spec:
           containerPort: 8000
         resources:
           limits:
-            memory: 2048Mi
+            memory: 4096Mi
             cpu: 2000m


### PR DESCRIPTION
Upped memory limit from 2 GB to 4 GB. Script now deletes service before replacing it.